### PR TITLE
Fix links to the blog in README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,7 +1,7 @@
 # Files for practice of shellgei
 
 Questions and answers are provided in the following page:
-https://blog.ueda.asia/?page_id=684
+https://b.ueda.tech/key.cgi?key=%E3%82%B7%E3%82%A7%E3%83%AB%E8%8A%B8
 
 Questions before 17th:
 https://github.com/gin135/ShellGeiData_01-17

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # シェル芸勉強会で使ったデータ集（第18回以降）
 
 問題と解答はこちら:
-https://blog.ueda.asia/?page_id=684
+https://b.ueda.tech/key.cgi?key=%E3%82%B7%E3%82%A7%E3%83%AB%E8%8A%B8
 
 17回目以前はこちら:
 https://github.com/gin135/ShellGeiData_01-17


### PR DESCRIPTION
README 内のブログへのリンクが古い方のブログ (現在証明書エラーになる) にむいていたので、新しい方のブログに変更しました。

問題一覧っぽい記事が見当たらなかったので、キーワード検索結果ページに向けるようにしてます。